### PR TITLE
Require System.Interactive.Async to be explicitly referenced

### DIFF
--- a/com.unity.ml-agents/Plugins/ProtoBuffer/System.Interactive.Async.dll.meta
+++ b/com.unity.ml-agents/Plugins/ProtoBuffer/System.Interactive.Async.dll.meta
@@ -9,6 +9,7 @@ PluginImporter:
   executionOrder: {}
   isPreloaded: 0
   isOverridable: 0
+  isExplicitlyReferenced: 1
   platformData:
   - first:
       Any: 


### PR DESCRIPTION
- Fixes #5799

### Proposed change(s)

- Fixes #5799

### Useful links (Github issues, JIRA tickets, ML-Agents forum threads etc.)

#5799

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

### Checklist
- [x] Added tests that prove my fix is effective or that my feature works **The issue went away.**
- [ ] Updated the [changelog](https://github.com/Unity-Technologies/ml-agents/blob/main/com.unity.ml-agents/CHANGELOG.md) (if applicable)
- [x] Updated the [documentation](https://github.com/Unity-Technologies/ml-agents/tree/main/docs) (if applicable) **Not applicable.**
- [x] Updated the [migration guide](https://github.com/Unity-Technologies/ml-agents/blob/main/docs/Migrating.md) (if applicable) **Not applicable.**

### Other comments
